### PR TITLE
Update ei_encode_long documentation to indicate variable length encoding.

### DIFF
--- a/lib/erl_interface/doc/references/ei.md
+++ b/lib/erl_interface/doc/references/ei.md
@@ -735,6 +735,7 @@ int ei_x_encode_long(ei_x_buff* x, long p);
 
 Encodes a long integer in the binary format. If the code is 64 bits, the
 function `ei_encode_long()` is the same as `ei_encode_longlong()`.
+This is a variable length encoding.
 
 ## ei_encode_longlong()
 


### PR DESCRIPTION
The function does not encode data to the fixed size of a long. Updating the documentation to reflect that.